### PR TITLE
Add test to install and automate extension inside DevTools

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -63,16 +63,16 @@ module.exports = {
       desiredCapabilities: {
         browserName: 'chrome',
         'goog:chromeOptions': {
-          // More info on Chromedriver: https://sites.google.com/a/chromium.org/chromedriver/
-          //
-          // w3c:false tells Chromedriver to run using the legacy JSONWire protocol (not required in Chrome 78)
-          w3c: true,
           args: [
-            //'--no-sandbox',
-            //'--ignore-certificate-errors',
-            //'--allow-insecure-localhost',
+            // to load extension from unpacked directory.
+            `--load-extension=${__dirname}/src`,
+            'auto-open-devtools-for-tabs'
             //'--headless'
-          ]
+          ],
+          // load extension from .crx file.
+          // extensions: [
+          //   require('fs').readFileSync('./dist/extension.crx', {encoding: 'base64'})
+          // ]
         }
       },
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepack": "npm run build",
     "postinstall": "npm run build",
     "eslint": "eslint index.js src --quiet",
-    "test": "npx nightwatch ./tests --headless"
+    "test": "npx nightwatch ./tests --env chrome --headless"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/testInstalledExtension.js
+++ b/tests/testInstalledExtension.js
@@ -1,0 +1,31 @@
+describe('test Nightwatch Inspector extension in DevTools', function() {
+  before(function() {
+    browser.navigateTo('https://nightwatchjs.org');
+  })
+
+  it('opens devtools, switches to extension tab and checks title', async function() {
+    const targets = await browser.driver.sendAndGetDevToolsCommand('Target.getTargets', {});
+
+    const devToolsTarget = targets.targetInfos.find(target => {
+      return target.type === 'page' &&
+        target.url.includes('devtools://devtools/bundled/devtools_app.html');
+    });
+
+    // switch to DevTools window context
+    await browser.window.switchTo(devToolsTarget.targetId);
+
+    // switch to last tab in pane (our extension)
+    await browser.sendKeys('body', [browser.Keys.COMMAND, '[']); // for macos
+    await browser.sendKeys('body', [browser.Keys.CONTROL, '[']); // for windows/linux
+
+    // switch to iframe inside "Nightwatch Inspector" tab
+    await browser.frame('iframe[src*="index.html"]');
+
+    // run automation on the extension
+    await browser.element('header').getText().assert.equals('Nightwatch Inspector');
+
+    // to visualize the extension during test run
+    await browser.pause(1000);
+  });
+});
+


### PR DESCRIPTION
This PR adds a test which installs the Nightwatch Inspector extension in the browser and then automates it inside the DevTools.

This test would only work in Chromium-based browsers.